### PR TITLE
Issue creating convex hull

### DIFF
--- a/cognitics/src/sfa/ConvexHull.cpp
+++ b/cognitics/src/sfa/ConvexHull.cpp
@@ -136,7 +136,7 @@ namespace sfa {
         int n = 0;
         for (int i = 0; i < num; i++)
         {
-            if ( (P[n]->p.Y() > P[i]->p.Y()) || (P[n]->p.Y() == P[i]->p.Y() && P[n]->p.X() < P[i]->p.X()) )
+            if ( (P[n]->p.Y() > P[i]->p.Y()) || (P[n]->p.Y() == P[i]->p.Y() && P[n]->p.X() > P[i]->p.X()) )
                 n = i;
         }
 


### PR DESCRIPTION
We had an issue creating a convex hull that we traced down to this function. From our understanding of the Graham scan algorithm when finding the "bottom" vertex and two Y coordinates equal, the smallest X value should be taken. The way the logic was written here it would take the value which has the greater value. If you guys need the values we were using to test let me know and I can dish them up in an email.